### PR TITLE
add timezone

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -84,7 +84,7 @@ stats.default <- function(df,
     labs(x = x_lab,
          y = y_lab,
          caption = paste(stringr::str_wrap(paste("Source:", usafacts_source), width = 100),
-                         paste("Data last updated:",timestamp()),
+                         paste("Data last updated:",timestamp(), "(Central time)"),
                          sep ="\n")
     )
 

--- a/R/timestamp.R
+++ b/R/timestamp.R
@@ -6,6 +6,6 @@ timestamp <- function() {
   
   date <- date()
   
-  formatted_date <- format(strptime(date, format = "%A %B %d %H:%M:%S %Y"), "%A, %B %d %I:%M:%S %p")
+  formatted_date <- format(strptime(date, format = "%A %B %d %H:%M:%S %Y", tz = "America/Chicago"), "%A, %B %d %I:%M:%S %p %Z")
    
 }


### PR DESCRIPTION
the problem was that if tz is not specified, R defaults to UTC. I also added %Z to the formatting so that it spits out the timezone. 

This means that the timestamp will always display in CDT even for users outside of CDT. It seems like that's our best option though